### PR TITLE
Fixes the release `400` error on smoke tests

### DIFF
--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -62,6 +62,17 @@ runs:
   - name: Define Channel Name
     shell: bash
     run: echo "CHANNEL_NAME=${{ github.ref_name }}-${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}-${{ inputs.kubernetes-distribution }}-${{ inputs.kubernetes-version }}" >> $GITHUB_ENV
+  - name: Update Chart YAML
+    id: update-chart-yaml
+    uses: mikefarah/yq@master
+    with:
+      cmd: yq '.version = "${APP_VERSION}"' ${CHART_YAML}
+  - name: Update Chart Version
+    id: update-chart-version
+    shell: bash
+    run: |
+      tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
+      tar -uzvf ${tarball} ${CHART_YAML}
   - name: 'Create Release'
     id: 'create-release'
     uses: replicatedhq/compatibility-actions/create-release@v0

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -72,10 +72,10 @@ runs:
     shell: bash
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
-      gunzip ${tarball} 
-      tar -uvf ${tarball%tgz}.tar ${CHART_YAML}
-      gzip ${tarball%tgz}.tar
-      mv ${tarball%tgz}.tar.gz ${tarball}
+      tar -xvf ${tarball%tgz} -C /tmp/repack
+      helm package --version "${{ env.APP_VERSION }}" /tmp/repack
+      mv /tmp/repack/${{ inputs.helm-chart-name }}-${{env.APP_VERSION }}.tgz $(dirname ${tarball })
+      rm ${tarball}
     env:
       YAML_DIR: ${{ inputs.yaml-dir }}
   - name: 'Create Release'

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -54,8 +54,6 @@ runs:
     uses: mikefarah/yq@master
     with:
       cmd: yq '.version' ${CHART_YAML}
-    env:
-      CHART_YAML: ${{ env.CHART_YAML }}
   - name: Define App Version
     shell: bash
     run: echo "APP_VERSION=${CHART_VERSION}-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: 'The directory containing multiple yamls for a Replicated release.'
     required: true
     default: 'manifests'
+  version:
+    description: 'Provides version to use for the Replicated Release'
+    reqired: false
   kubernetes-distribution:
     description: 'Kubernetes distribution of the cluster to provision.'
     required: true
@@ -41,6 +44,7 @@ runs:
   steps:
   - name: Extract Chart YAML
     id: extract-chart-yaml
+    if: inputs.version == ''
     shell: bash
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
@@ -51,27 +55,36 @@ runs:
       CHART_NAME: ${{ inputs.helm-chart-name }}
   - name: Get Chart Version
     id: get-chart-version
+    if: inputs.version == ''
     uses: mikefarah/yq@master
     with:
       cmd: yq '.version' ${CHART_YAML}
   - name: Define App Version
     shell: bash
+    if: inputs.version == ''
     run: echo "APP_VERSION=${CHART_VERSION}+${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
     env:
       CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
+  - name: Use Explicit Version
+    shell: bash
+    if: inputs.version != ''
+    run: echo "APP_VERSION=${VERSION}" >> $GITHUB_ENV
+    env:
+      VERSION: ${{ inputs.version }}
   - name: Define Channel Name
     shell: bash
     run: echo "CHANNEL_NAME=${{ github.ref_name }}-${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}-${{ inputs.kubernetes-distribution }}-${{ inputs.kubernetes-version }}" >> $GITHUB_ENV
   - name: Update Chart YAML
     id: update-chart-yaml
+    if: inputs.version == ''
     uses: mikefarah/yq@master
     with:
       cmd: yq  -i '.version = "${{ env.APP_VERSION }}"' ${CHART_YAML}
   - name: Update Chart Version
     id: update-chart-version
     shell: bash
-    if: ${{ inputs.installation-method == 'helm' }}
-    run: |
+    if: inputs.installation-method == 'helm' && inputs.version == ''
+    run:  |
       # update the chart version to match the Replicated app version
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
       mkdir -p /tmp/repack
@@ -81,6 +94,7 @@ runs:
       rm ${tarball}
     env:
       YAML_DIR: ${{ inputs.yaml-dir }}
+      CHART_NAME: ${{ inputs.helm-chart-name }}
   - name: 'Create Release'
     id: 'create-release'
     uses: replicatedhq/compatibility-actions/create-release@v0

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -74,9 +74,10 @@ runs:
     run: |
       # update the chart version to match the Replicated app version
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
-      tar -xvf ${tarball%tgz} -C /tmp/repack
-      helm package --version "${{ env.APP_VERSION }}" /tmp/repack
-      mv /tmp/repack/${{ inputs.helm-chart-name }}-${{env.APP_VERSION }}.tgz $(dirname ${tarball })
+      mkdir -p /tmp/repack
+      tar -xf ${tarball} -C /tmp/repack
+      helm package --version "${{ env.APP_VERSION }}" /tmp/repack/${CHART_NAME}*
+      mv ${{ inputs.helm-chart-name }}-${{env.APP_VERSION }}.tgz $(dirname ${tarball})
       rm ${tarball}
     env:
       YAML_DIR: ${{ inputs.yaml-dir }}

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -45,7 +45,7 @@ runs:
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
       chart_yaml=$(tar -xzvf ${tarball} $(tar -tzf ${tarball} | grep Chart.yaml))
-      echo "chart-yaml=${chart_yaml}" >> $GITHUB_OUTPUT
+      echo "CHART_YAML=${chart_yaml}" >> $GITHUB_ENV
     env:
       YAML_DIR: ${{ inputs.yaml-dir }}
       CHART_NAME: ${{ inputs.helm-chart-name }}
@@ -53,7 +53,9 @@ runs:
     id: get-chart-version
     uses: mikefarah/yq@master
     with:
-      cmd: yq '.version' ${{ steps.extract-chart-yaml.outputs.chart-yaml }}
+      cmd: yq '.version' ${CHART_YAML}
+    env:
+      CHART_YAML: ${{ env.CHART_YAML }}
   - name: Define App Version
     shell: bash
     run: echo "APP_VERSION=${CHART_VERSION}-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -39,9 +39,26 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Extract Chart YAML
+    id: extract-chart-yaml
+    shell: bash
+    run: |
+      tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
+      chart_yaml=$(tar -xzvf ${tarball} $(tar -tzf ${tarball} | grep Chart.yaml))
+      echo "chart-yaml=${chart_yaml}" >> $GITHUB_OUTPUT
+    env:
+      YAML_DIR: ${{ inputs.yaml-dir }}
+      CHART_NAME: ${{ inputs.helm-chart-name }}
+  - name: Get Chart Version
+    id: get-chart-version
+    uses: mikefarah/yq@master
+    with:
+      cmd: yq '.version' ${{ steps.extract-chart-yaml.outputs.chart-yaml }}
   - name: Define App Version
     shell: bash
-    run: echo "APP_VERSION=0.0.1-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
+    run: echo "APP_VERSION=${CHART_VERSION}-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
+    env:
+      CHART_VERSION: ${{ steps.get-chart-version.outputs.results }}
   - name: Define Channel Name
     shell: bash
     run: echo "CHANNEL_NAME=${{ github.ref_name }}-${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}-${{ inputs.kubernetes-distribution }}-${{ inputs.kubernetes-version }}" >> $GITHUB_ENV

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -44,7 +44,7 @@ runs:
     shell: bash
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
-      chart_yaml=$(tar -xzvf ${tarball} $(tar -tzf ${tarball} | grep Chart.yaml))
+      chart_yaml=$(tar -xzvf ${tarball} $(tar -tzf ${tarball} --exclude "*/charts/*" | grep Chart.yaml))
       echo "CHART_YAML=${chart_yaml}" >> $GITHUB_ENV
     env:
       YAML_DIR: ${{ inputs.yaml-dir }}

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -66,13 +66,18 @@ runs:
     id: update-chart-yaml
     uses: mikefarah/yq@master
     with:
-      cmd: yq '.version = "${APP_VERSION}"' ${CHART_YAML}
+      cmd: yq  -i '.version = "${{ env.APP_VERSION }}"' ${CHART_YAML}
   - name: Update Chart Version
     id: update-chart-version
     shell: bash
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
-      tar -uzvf ${tarball} ${CHART_YAML}
+      gunzip ${tarball} 
+      tar -uvf ${tarball%tgz}.tar ${CHART_YAML}
+      gzip ${tarball%tgz}.tar
+      mv ${tarball%tgz}.tar.gz ${tarball}
+    env:
+      YAML_DIR: ${{ inputs.yaml-dir }}
   - name: 'Create Release'
     id: 'create-release'
     uses: replicatedhq/compatibility-actions/create-release@v0

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -60,7 +60,7 @@ runs:
     shell: bash
     run: echo "APP_VERSION=${CHART_VERSION}-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
     env:
-      CHART_VERSION: ${{ steps.get-chart-version.outputs.results }}
+      CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
   - name: Define Channel Name
     shell: bash
     run: echo "CHANNEL_NAME=${{ github.ref_name }}-${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}-${{ inputs.kubernetes-distribution }}-${{ inputs.kubernetes-version }}" >> $GITHUB_ENV

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -70,7 +70,9 @@ runs:
   - name: Update Chart Version
     id: update-chart-version
     shell: bash
+    if: ${{ inputs.installation-method == 'helm' }}
     run: |
+      # update the chart version to match the Replicated app version
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
       tar -xvf ${tarball%tgz} -C /tmp/repack
       helm package --version "${{ env.APP_VERSION }}" /tmp/repack

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: 'manifests'
   version:
     description: 'Provides version to use for the Replicated Release'
-    reqired: false
+    required: false
   kubernetes-distribution:
     description: 'Kubernetes distribution of the cluster to provision.'
     required: true
@@ -44,7 +44,7 @@ runs:
   steps:
   - name: Extract Chart YAML
     id: extract-chart-yaml
-    if: inputs.version == ''
+    if: inputs.installation-method == 'helm' && inputs.version == ''
     shell: bash
     run: |
       tarball=$(find ${YAML_DIR} -name "${CHART_NAME}*.tgz")
@@ -55,14 +55,21 @@ runs:
       CHART_NAME: ${{ inputs.helm-chart-name }}
   - name: Get Chart Version
     id: get-chart-version
-    if: inputs.version == ''
+    if: inputs.installation-method == 'helm' && inputs.version == ''
     uses: mikefarah/yq@master
     with:
       cmd: yq '.version' ${CHART_YAML}
   - name: Define App Version
     shell: bash
-    if: inputs.version == ''
+    if: inputs.installation-method == 'helm' && inputs.version == ''
     run: echo "APP_VERSION=${CHART_VERSION}+${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
+    env:
+      CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
+  # there no good default here, going back to what Josh had since it's specific to the channel and the channel goes away
+  - name: Define App Version
+    shell: bash
+    if: inputs.installation-method == 'kots' && inputs.version == ''
+    run: echo "APP_VERSION=0.1.0+${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
     env:
       CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
   - name: Use Explicit Version

--- a/smoke-test/action.yml
+++ b/smoke-test/action.yml
@@ -56,7 +56,7 @@ runs:
       cmd: yq '.version' ${CHART_YAML}
   - name: Define App Version
     shell: bash
-    run: echo "APP_VERSION=${CHART_VERSION}-${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
+    run: echo "APP_VERSION=${CHART_VERSION}+${GITHUB_REF_NAME//[^a-zA-Z0-9]/}.${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}" >> $GITHUB_ENV
     env:
       CHART_VERSION: ${{ steps.get-chart-version.outputs.result }}
   - name: Define Channel Name


### PR DESCRIPTION
TL;DR
-----

Makes sure versions are aligned when running smoke tests

Details
-------

Replaces hardcode major.minor.patch of `0.0.1` from the version used in the smoke action and replaces it with the version from the Helm chart's `Chart.yaml`. I thought that would be all that was required to fix the `400` on release, but it wasn't. So now the smoke test also updates `Chart.yaml` with the version that it creates to use for the test release. This required by the strict rules the vendor portal has for validating that the release version matches the chart version.

Ideally we could stash the build related tagging into the build metadata fragment of the semver instead of the prerelease version, and the vendor portal could ignore build metadata.