### PR TITLE
chore: add Dependabot and npm audit CI check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: build
         run: make
 
+      - name: audit
+        run: npm audit --audit-level=high
+
       - name: fail if files changed
         run: |
           if ! git diff --quiet --exit-code ; then


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated weekly npm dependency updates — all updates are grouped into a single Monday PR to reduce noise (matches the `npm_and_yarn` group pattern already used in this repo's commit history)
- Adds an `npm audit --audit-level=high` step to `ci.yml` so any HIGH or CRITICAL severity vulnerability introduced by a future dependency change will fail CI before merging

## Test plan

- [ ] Dependabot appears under Settings → Code security → Dependabot after merging
- [ ] CI audit step passes on the current clean dependency tree
- [ ] A PR with a known HIGH vuln would fail the audit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)