### PR TITLE
Update README.md to reflect GitHub repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Compatibility Actions
+# Replicated Actions
 
 ## Examples
 
@@ -12,7 +12,7 @@ Based on your preference you can either use the simplified prepare-cluster versi
 
 See the [example workflow](example-workflows/development-helm-prepare-cluster.yaml) for more details and also the [prepare-cluster](prepare-cluster) directory for the actual action.
 
-https://github.com/replicatedhq/replicated-actions/blob/71c3cdf8e9b72754fdad6394238d5f872c1b8c65/example-workflows/development-helm-prepare-cluster.yaml#L1-L35
+https://github.com/replicatedhq/replicated-actions/blob/6803131db735f7cc067de88fa14237c7462b247a/example-workflows/development-helm-prepare-cluster.yaml#L1-L35
 
 #### Customizable
 
@@ -20,13 +20,13 @@ https://github.com/replicatedhq/replicated-actions/blob/71c3cdf8e9b72754fdad6394
 
 See the [example workflow](example-workflows/development-helm.yaml) for more details.
 
-https://github.com/replicatedhq/replicated-actions/blob/71c3cdf8e9b72754fdad6394238d5f872c1b8c65/example-workflows/development-helm.yaml#L1-L140
+https://github.com/replicatedhq/replicated-actions/blob/6803131db735f7cc067de88fa14237c7462b247a/example-workflows/development-helm.yaml#L1-L140
 
 ##### Installation with KOTS
 
 See the [example workflow](example-workflows/development-kots.yaml) for more details.
 
-https://github.com/replicatedhq/replicated-actions/blob/71c3cdf8e9b72754fdad6394238d5f872c1b8c65/example-workflows/development-kots.yaml#L1-L133
+https://github.com/replicatedhq/replicated-actions/blob/6803131db735f7cc067de88fa14237c7462b247a/example-workflows/development-kots.yaml#L1-L133
 
 ### Releasing
 
@@ -35,7 +35,7 @@ The next job will setup a compatibility matrix of clusters, deploy the app and e
 
 See the [example workflow](example-workflows/release.yaml) for more details.
 
-https://github.com/replicatedhq/replicated-actions/blob/71c3cdf8e9b72754fdad6394238d5f872c1b8c65/example-workflows/release.yaml#L1-L151
+https://github.com/replicatedhq/replicated-actions/blob/6803131db735f7cc067de88fa14237c7462b247a/example-workflows/release.yaml#L1-L151
 
 ## Local Development
 


### PR DESCRIPTION
I noticed the readme links to stale code and refers to the repo as to old `compatibility-actions`  in the stale PR, so I put up a PR to correct this. It permalinks to the current commit SHA of the `main` branch: 
<img width="1904" height="907" alt="image" src="https://github.com/user-attachments/assets/da877e5b-bd7b-40f6-977a-eafba2fa73e1" />
